### PR TITLE
Add a guard to not fire open-external event with empty parameter.

### DIFF
--- a/movim/browser.js
+++ b/movim/browser.js
@@ -2,7 +2,9 @@ const {ipcRenderer} = require('electron');
 
 window.electron = {
     openExternal: function(url) {
-        ipcRenderer.send('open-external', url);
+        if (url) {
+            ipcRenderer.send('open-external', url);
+        }
     },
     notification: function(counter) {
         ipcRenderer.send('notification', ~~counter);


### PR DESCRIPTION
Fixes #6